### PR TITLE
Corrected some file paths and fixed some broken formatting in code blocks.

### DIFF
--- a/docs/source/cross_compile/call_shared_library.rst
+++ b/docs/source/cross_compile/call_shared_library.rst
@@ -158,7 +158,7 @@ function from that library. The example library only has one function,
 so this is straight forward.
 
 1. In the *src* directory of the project, create a new source file
-   titled *callingSharedLibary.c.*
+   titled *callingSharedLibrary.c.*
 
 2. Complete the source file as shown below.
 

--- a/docs/source/cross_compile/call_shared_library.rst
+++ b/docs/source/cross_compile/call_shared_library.rst
@@ -412,7 +412,7 @@ debugging <https://code.visualstudio.com/docs/cpp/launch-json-reference>`__.
             "environment": [],
             "showDisplayString": true,
             "MIMode": "gdb",
-            "miDebuggerPath": "C:/build/18.0/x64/sysroots/i686-nilrtsdkmingw32/usr/bin/x86_64-nilrt-linux/x86_64-nilrt-linux-gdb.exe",
+            "miDebuggerPath": "C:/build/18.0/x64/sysroots/i686-nilrtsdk-mingw32/usr/bin/x86_64-nilrt-linux/x86_64-nilrt-linux-gdb.exe",
             "miDebuggerServerAddress": "10.2.110.136:9092"
           }
         ]

--- a/docs/source/cross_compile/config_vs_code.rst
+++ b/docs/source/cross_compile/config_vs_code.rst
@@ -195,7 +195,8 @@ includes and other necessary resources.
                  "--sysroot=${compilerSysroots}/core2-64-nilrt-linux/"
                ],
                "includePath": [
-                 "${workspaceFolder}/"
+                 "${workspaceFolder}/",
+                 "${workspaceFolder}/core2-64-nilrt-linux/usr/include/"
                ],
                "intelliSenseMode": "gcc-x64"
              }
@@ -219,7 +220,8 @@ includes and other necessary resources.
                  "--sysroot=${compilerSysroots}/cortexa9-vfpv3-nilrt-linuxgnueabi/"
                ],
                "includePath": [
-                 "${workspaceFolder}/"
+                 "${workspaceFolder}/",
+                 "${compilerSysroots}/cortexa9-vfpv3-nilrt-linux-gnueabi/usr/include/"
                ],
                "intelliSenseMode": "gcc-x86"
              }

--- a/docs/source/cross_compile/config_vs_code.rst
+++ b/docs/source/cross_compile/config_vs_code.rst
@@ -190,7 +190,7 @@ includes and other necessary resources.
            "configurations": [
              {
                "name": "NI Linux Real-Time x64",
-               "compilerPath": "${compilerSysroots}/i686-nilrtsdkmingw32/usr/bin/x86_64-nilrt-linux/x86_64-nilrt-linux-gcc",
+               "compilerPath": "${compilerSysroots}/i686-nilrtsdk-mingw32/usr/bin/x86_64-nilrt-linux/x86_64-nilrt-linux-gcc.exe",
                "compilerArgs": [
                  "--sysroot=${compilerSysroots}/core2-64-nilrt-linux/"
                ],
@@ -214,7 +214,7 @@ includes and other necessary resources.
            "configurations": [
              {
                "name": "NI Linux Real-Time ARMv7",
-               "compilerPath": "${compilerSysroots}/i686-nilrtsdkmingw32/usr/bin/arm-nilrt-linux-gnueabi/arm-nilrt-linux-gnueabi-gcc",
+               "compilerPath": "${compilerSysroots}/i686-nilrtsdk-mingw32/usr/bin/arm-nilrt-linux-gnueabi/arm-nilrt-linux-gnueabi-gcc.exe",
                "compilerArgs": [
                  "--sysroot=${compilerSysroots}/cortexa9-vfpv3-nilrt-linuxgnueabi/"
                ],
@@ -285,7 +285,7 @@ debugging <https://code.visualstudio.com/docs/cpp/launch-json-reference>`__.
                "environment": [],
                "showDisplayString": true,
                "MIMode": "gdb",
-               "miDebuggerPath": "C:/build/18.0/x64/sysroots/i686-nilrtsdkmingw32/usr/bin/x86_64-nilrt-linux/x86_64-nilrt-linux-gdb.exe",
+               "miDebuggerPath": "C:/build/18.0/x64/sysroots/i686-nilrtsdk-mingw32/usr/bin/x86_64-nilrt-linux/x86_64-nilrt-linux-gdb.exe",
                "miDebuggerServerAddress": "serveraddress:port"
              }
            ]
@@ -310,7 +310,7 @@ debugging <https://code.visualstudio.com/docs/cpp/launch-json-reference>`__.
                "environment": [],
                "showDisplayString": true,
                "MIMode": "gdb",
-               "miDebuggerPath": "C:/build/18.0/arm/sysroots/i686-nilrtsdkmingw32/usr/bin/arm-nilrt-linux-gnueabi/arm-nilrt-linux-gnueabi-gdb.exe",
+               "miDebuggerPath": "C:/build/18.0/arm/sysroots/i686-nilrtsdk-mingw32/usr/bin/arm-nilrt-linux-gnueabi/arm-nilrt-linux-gnueabi-gdb.exe",
                "miDebuggerServerAddress": "serveraddress:port"
              }
            ]

--- a/docs/source/cross_compile/config_vs_code.rst
+++ b/docs/source/cross_compile/config_vs_code.rst
@@ -421,17 +421,19 @@ used.
       set(CMAKE_<LANG>_FLAGS_RELEASE "-O3")
 
    2. For NI Linux Real-Time ARM targets:
-      .. code:: cmake
 
-         set(CMAKE_SYSROOT ${toolchainpath}/cortexa9-vfpv3-nilrt-linux-gnueabi)
-         set(CMAKE_<LANG>_STANDARD_INCLUDE_DIRECTORIES ${toolchainpath}/cortexa9-vfpv3-nilrt-linuxgnueabi/usr/include/c++/6.3.0 ${toolchainpath}/cortexa9-vfpv3-nilrt-linuxgnueabi/usr/include/c++/6.3.0/arm-nilrt-linux-gnueabi)
-         set(CMAKE_<LANG>_FLAGS "-Wall -fmessage-length=0 -mfpu=vfpv3 -mfloat-abi=softfp")
-         set(CMAKE_<LANG>_FLAGS_DEBUG "-O0 -g3")
-         set(CMAKE_<LANG>_FLAGS_RELEASE "-O3")
+   .. code:: cmake
 
-      **Note:** NI recommends using the **-mfpu=vfpv3
-      -mfloat-abi=softfp** flags for ARM targets to improve
-      floating-point operation performance.
+      set(CMAKE_SYSROOT ${toolchainpath}/cortexa9-vfpv3-nilrt-linux-gnueabi)
+      set(CMAKE_<LANG>_STANDARD_INCLUDE_DIRECTORIES ${toolchainpath}/cortexa9-vfpv3-nilrt-linuxgnueabi/usr/include/c++/6.3.0 ${toolchainpath}/cortexa9-vfpv3-nilrt-linuxgnueabi/usr/include/c++/6.3.0/arm-nilrt-linux-gnueabi)
+      set(CMAKE_<LANG>_FLAGS "-Wall -fmessage-length=0 -mfpu=vfpv3 -mfloat-abi=softfp")
+      set(CMAKE_<LANG>_FLAGS_DEBUG "-O0 -g3")
+      set(CMAKE_<LANG>_FLAGS_RELEASE "-O3")
+
+
+   **Note:** NI recommends using the **-mfpu=vfpv3
+   -mfloat-abi=softfp** flags for ARM targets to improve
+   floating-point operation performance.
 
 6. Search behavior must be specified to ensure that the compiler doesn’t
    unnecessarily pull in includes from the host system’s paths. This

--- a/docs/source/cross_compile/hello_world.rst
+++ b/docs/source/cross_compile/hello_world.rst
@@ -122,6 +122,7 @@ documentation <https://cmake.org/cmake/help/latest/>`__.
 1. Open the *<project directory>/build/CMakeLists.txt* file in the
    Visual Studio Code editor.
 2. Add the following lines to the end of the file.
+
    .. code:: cmake
 
       # project specific information
@@ -327,7 +328,7 @@ debugging <https://code.visualstudio.com/docs/cpp/launch-json-reference>`__.
             "environment": [],
             "showDisplayString": true,
             "MIMode": "gdb",
-            "miDebuggerPath": "C:/build/18.0/x64/sysroots/i686-nilrtsdkmingw32/usr/bin/x86_64-nilrt-linux/x86_64-nilrt-linux-gdb.exe",
+            "miDebuggerPath": "C:/build/18.0/x64/sysroots/i686-nilrtsdk-mingw32/usr/bin/x86_64-nilrt-linux/x86_64-nilrt-linux-gdb.exe",
             "miDebuggerServerAddress": "10.2.110.136:9092"
           }
         ]


### PR DESCRIPTION
When we actually built the compile environment, we found the following problem.
These have been corrected.

* There was a description error in the compiler and debugger file paths.
* The include path required to build "HelloWorld" was missing.
* Some parts were not recognized as code blocks and were formatted incorrectly.

