### PR TITLE
Preserve CNAME and CODEOWNERS in gh-pages branch.

### DIFF
--- a/.github/workflows/publish-page.yml
+++ b/.github/workflows/publish-page.yml
@@ -17,6 +17,9 @@ jobs:
       with:
         target_branch: 'gh-pages'
         documentation_path: './docs/source'
+    - name: Preserve Configuration Files
+      run: |
+        git checkout main -- CNAME CODEOWNERS
     - name: Create Pull Request
       uses: peter-evans/create-pull-request@v4
       with:


### PR DESCRIPTION
Currently, the workflow which publishes to the
gh-pages branch will blow away any files not
created as part of publishing. This adds a step
to the workflow to ensure config files are kept.

Signed-off-by: Charlie Johnston <charlie.johnston@ni.com>