### PR TITLE
Fix-up branch for CNAME in workflow.

### DIFF
--- a/.github/workflows/publish-page.yml
+++ b/.github/workflows/publish-page.yml
@@ -19,7 +19,8 @@ jobs:
         documentation_path: './docs/source'
     - name: Preserve Configuration Files
       run: |
-        git checkout main -- CNAME CODEOWNERS
+        git checkout main -- CODEOWNERS
+        git checkout gh-pages -- CNAME
     - name: Create Pull Request
       uses: peter-evans/create-pull-request@v4
       with:


### PR DESCRIPTION
CNAME doesn't exist in main, just in
gh-pages. This checks it out from the
correct branch.

Signed-off-by: Charlie Johnston <charlie.johnston@ni.com>