### PR TITLE
Pointing to proper gh-pages ref in workflow.

### DIFF
--- a/.github/workflows/publish-page.yml
+++ b/.github/workflows/publish-page.yml
@@ -20,7 +20,7 @@ jobs:
     - name: Preserve Configuration Files
       run: |
         git checkout main -- CODEOWNERS
-        git checkout gh-pages -- CNAME
+        git checkout gh-pages^ -- CNAME
     - name: Create Pull Request
       uses: peter-evans/create-pull-request@v4
       with:


### PR DESCRIPTION
The workflow ends up making a commit to gh-pages,
so we need to point to gh-pages^.

Signed-off-by: Charlie Johnston <charlie.johnston@ni.com>