### PR TITLE
Document pstore-save mechanism for support purposes.

### DIFF
--- a/docs/source/index.rst
+++ b/docs/source/index.rst
@@ -16,3 +16,4 @@ NI Linux Real-Time Documentation and Tutorials
    cross_compile/cross_compile_index
    remote/vscode_remote_index
    opkg/opkg_tutorials_index
+   troubleshooting/troubleshooting_index

--- a/docs/source/troubleshooting/pstore.rst
+++ b/docs/source/troubleshooting/pstore.rst
@@ -1,0 +1,26 @@
+==========================================================
+Obtaining Kernel Logs from a Prior System Crash Via pstore
+==========================================================
+
+Description
+============
+On Linux, the dmesg log (i.e., the log printed from the `dmesg` command) is the kernel message buffer. Any `printk` kernel message logs end up here. \
+When the kernel crashes, a stack trace is printed to the kernel message buffer. Unfortunately, a crash typically means the system reboots which will \
+wipe out any values in the kernel message buffer.
+
+On x64 platforms, the last lines of the kernel message buffer can be placed into EFI variable storage via the pstore mechanism when a kernel crash occurs; this allows them to be retrieved on next boot.
+
+As of NI Linux Real-Time 21.3, the system will automatically copy logs out of EFI storage into the `/var/lib/pstore/[YYYYMMDD_hhmmss]/` directory. \
+Reconstructed dmesg information will be files named dmesg-001.txt, where 001 is the numeric count of the "oops" (it's possible for there to be multiple \
+"oops"es from different CPU cores).
+
+If a kernel crash occurred and dmesg information was reconstructed, messages will be printed to the kernel message buffer and system log of the \
+current boot. For example: 
+
+::
+
+    admin@NI-cRIO-9035-01234567:~# cat /var/log/messages | grep pstore-save
+    2022-08-19T20:50:04.921+00:00 NI-cRIO-9035-01234567 [    1.143127] pstore-save: Saving prior dmesg from crash to /var/lib/pstore/20220819_204926
+
+This implementation of saving logs from `pstore` is intended to mimic `systemd-pstore` on systems which have `systemd` enabled. However, this implementation is simpler \
+and there may be differences in behavior.

--- a/docs/source/troubleshooting/troubleshooting_index.rst
+++ b/docs/source/troubleshooting/troubleshooting_index.rst
@@ -1,0 +1,10 @@
+======================================
+NI Linux Real-Time Debug Documentation
+======================================
+
+.. toctree::
+   :maxdepth: 2
+   :caption: Contents:
+   :glob:
+
+   ./*


### PR DESCRIPTION
We have a mechanism to obtain kernel logs from
kernel crashes after a system reboot. This adds
documentation that we can point support or customers
to for finding those logs.

Signed-off-by: Charlie Johnston <charlie.johnston@ni.com>

**Note:** I used the documentation [here ](https://dev.azure.com/ni/DevCentral/_wiki/wikis/AppCentral.wiki/21242/Crash-Logging-Facilities-in-NILRT?anchor=saved-dmesg-logs-(x64-only))as a source for this. 

AzDO Work Item: https://dev.azure.com/ni/DevCentral/_workitems/edit/1991389/

## Testing
![2022-08-22 15_53_49-Window](https://user-images.githubusercontent.com/5367780/186017726-b279d05f-ba50-4264-9fce-544e930f54bd.png)