### PR TITLE
Add documentation on crash debugging and remove unnecessary header

### DIFF
--- a/docs/source/troubleshooting/pstore.rst
+++ b/docs/source/troubleshooting/pstore.rst
@@ -2,8 +2,6 @@
 Obtaining Kernel Logs from a Prior System Crash Via pstore
 ==========================================================
 
-Description
-============
 On Linux, the dmesg log (i.e., the log printed from the `dmesg` command) is the kernel message buffer. Any `printk` kernel message logs end up here. \
 When the kernel crashes, a stack trace is printed to the kernel message buffer. Unfortunately, a crash typically means the system reboots which will \
 wipe out any values in the kernel message buffer.


### PR DESCRIPTION
Adding documentation on generating lvrt core dumps

Documentation on how to enable core dumps for lvrt is
currently internal. Creating an external page with the
customer portion of the instructions.

Signed-off-by: Charlie Johnston <charlie.johnston@ni.com>

AzDO Work Item: https://dev.azure.com/ni/DevCentral/_workitems/edit/1993491/

## Testing:
Built locally:
![image](https://user-images.githubusercontent.com/5367780/186778286-8fb2ec48-cff4-489d-ba27-ab8b85d38042.png)

I also ran through the instructions again to address a few typos/issues.
