### PR TITLE
Adding new logging for lvrt crashes to core dump documentation.

### DIFF
--- a/docs/source/troubleshooting/lvrt-crash-dumps.rst
+++ b/docs/source/troubleshooting/lvrt-crash-dumps.rst
@@ -147,7 +147,27 @@ To confirm core dumps are properly configured, it's possible to force a crash of
 
 	This command will send a SIGSEGV to the lvrt process.
 
-#. Confirm that the lvrt process crashed by running the following command:
+#. Confirm that the lvrt process crashed.
+
+	**LabVIEW Real-Time >= 23.1**
+
+	A message will be logged to the system log at `/var/log/messages` if a crash occurs.
+	Run the following command to confirm the crash was logged.
+
+	.. code:: bash
+
+		cat /var/log/messages | tail
+
+	This will show the last 10 messages logged.
+	If a crash occurred, the a message similer to the following should be present:
+
+	.. code:: bash
+
+		lvrt-daemon: The LabVIEW Real-Time Process has encountered an error. Check /var/local/natinst/log for error logs.
+
+	**LabVIEW Real-Time < 23.1**
+
+	Run the following command:
 
 	.. code:: bash
 


### PR DESCRIPTION
The lvrt process will now log to the messages log if it crashes. This PR adds that information to the troubleshooting documentation for LV core dumps.

Signed-off-by: Charlie Johnston <charlie.johnston@ni.com>

AzDO Work Item: https://dev.azure.com/ni/DevCentral/_workitems/edit/1991384/

## Testing
Built locally:
![image](https://user-images.githubusercontent.com/5367780/189443447-d174a5b4-07c5-4051-8284-37de446c01bf.png)
