### PR TITLE
cross_compile: Update docs for 23.0 release changes.

### DIFF
--- a/docs/source/cross_compile/call_shared_library.rst
+++ b/docs/source/cross_compile/call_shared_library.rst
@@ -388,10 +388,10 @@ debugging <https://code.visualstudio.com/docs/cpp/launch-json-reference>`__.
    information such as the **miDebuggerPath** completed already as part
    of the template project creation.
 
-2. Complete *launch.json* for the “Hello, World!” application as shown
-   below. Specifically, the **program** and **miDebuggerServerAddress**
-   fields using the IP address of the remote NI Linux Real-Time device
-   and the local binary build.
+2. Complete *launch.json* for the shared libaray application as shown
+   in the example for version 18.0 below. Specifically, the **program**
+   and **miDebuggerServerAddress** fields using the IP address of the
+   remote NI Linux Real-Time device and the local binary build.
 
    .. code:: json
 

--- a/docs/source/cross_compile/config_dev_system.rst
+++ b/docs/source/cross_compile/config_dev_system.rst
@@ -36,7 +36,7 @@ each tool and how to set it up.
 -  One of the following compiler toolchains:
 
    -  `GNU C & C++ Compilers for x64
-      Linux <https://www.ni.com/en-us/support/downloads/software-products/download.gnu-c---c---compile-tools-x64.html#338442>`__
+      Linux <https://www.ni.com/en-us/support/downloads/software-products/download.gnu-c---c---compile-tools-x64.html#477802>`__
       (Windows host) 2017 or later
    -  `GNU C & C++ Compilers for ARMv7
       Linux <https://www.ni.com/en-us/support/downloads/software-products/download.gnu-c---c---compile-tools-for-armv7.html#338448>`__
@@ -141,7 +141,7 @@ the right location.
 
 4. | If using a x64 target, extract and copy the contents of the toolchain
      to *C:\\build\\<toolchain version>\\x64\\*. The resulting file structure
-     should look as follows:
+     should look similar to the following:
 
    .. image:: media/config_pc/image5.png
 

--- a/docs/source/cross_compile/config_vs_code.rst
+++ b/docs/source/cross_compile/config_vs_code.rst
@@ -190,7 +190,7 @@ includes and other necessary resources.
 
          {
            "env": {
-             "compilerSysroots": "C:/build/18.0/x64/sysroots/"
+             "compilerSysroots": "C:/build/<toolchain version>/x64/sysroots/"
            },
            "configurations": [
              {
@@ -209,13 +209,15 @@ includes and other necessary resources.
            "version": 4
          }
 
+      | **Note:** For toolchain versions 2023Q1 and later, the `compilerPath` is instead `${compilerSysroots}/x86_64-w64-mingw32/usr/bin/x86_64-nilrt-linux/x86_64-nilrt-linux-gcc.exe`.
+
    2. | For NI Linux Real-Time ARM devices, complete the file as follows:
 
       .. code:: json
 
          {
            "env": {
-             "compilerSysroots": "C:/build/18.0/arm/sysroots/"
+             "compilerSysroots": "C:/build/<toolchain version>/arm/sysroots/"
            },
            "configurations": [
              {
@@ -292,11 +294,13 @@ debugging <https://code.visualstudio.com/docs/cpp/launch-json-reference>`__.
                "environment": [],
                "showDisplayString": true,
                "MIMode": "gdb",
-               "miDebuggerPath": "C:/build/18.0/x64/sysroots/i686-nilrtsdk-mingw32/usr/bin/x86_64-nilrt-linux/x86_64-nilrt-linux-gdb.exe",
+               "miDebuggerPath": "C:/build/<toolchain version>/x64/sysroots/i686-nilrtsdk-mingw32/usr/bin/x86_64-nilrt-linux/x86_64-nilrt-linux-gdb.exe",
                "miDebuggerServerAddress": "serveraddress:port"
              }
            ]
          }
+
+      | **Note:** For toolchain versions 2023Q1 and later, the `miDebuggerPath` is `C:/build/<toolchain version>/x64/sysroots/x86_64-w64-mingw32/usr/bin/x86_64-nilrt-linux/x86_64-nilrt-linux-gdb.exe`.
 
    2. | For NI Linux Real-Time ARM devices, complete the file as follows:
 
@@ -317,7 +321,7 @@ debugging <https://code.visualstudio.com/docs/cpp/launch-json-reference>`__.
                "environment": [],
                "showDisplayString": true,
                "MIMode": "gdb",
-               "miDebuggerPath": "C:/build/18.0/arm/sysroots/i686-nilrtsdk-mingw32/usr/bin/arm-nilrt-linux-gnueabi/arm-nilrt-linux-gnueabi-gdb.exe",
+               "miDebuggerPath": "C:/build/<toolchain version>/arm/sysroots/i686-nilrtsdk-mingw32/usr/bin/arm-nilrt-linux-gnueabi/arm-nilrt-linux-gnueabi-gdb.exe",
                "miDebuggerServerAddress": "serveraddress:port"
              }
            ]
@@ -387,13 +391,13 @@ used.
 
    .. code:: cmake
 
-      set(toolchainpath C:/build/18.0/x64/sysroots)
+      set(toolchainpath C:/build/<toolchain version>/x64/sysroots)
 
    2. For NI Linux Real-Time ARM targets:
 
    .. code:: cmake
 
-      set(toolchainpath C:/build/18.0/arm/sysroots)
+      set(toolchainpath C:/build/<toolchain version>/arm/sysroots)
 
 4. Next, configure the compilers for both C and C++. CMake will
    automatically decide which compiler to used based on the files being
@@ -406,6 +410,8 @@ used.
       set(CMAKE_C_COMPILER ${toolchainpath}/i686-nilrtsdk-mingw32/usr/bin/x86_64-nilrt-linux/x86_64-nilrt-linux-gcc.exe)
       set(CMAKE_CXX_COMPILER ${toolchainpath}/i686-nilrtsdk-mingw32/usr/bin/x86_64-nilrt-linux/x86_64-nilrt-linux-g++.exe)
 
+   **Note:** For toolchain versions 2023Q1 and later, replace `i686-nilrtsdk-mingw32` with `x86_64-w64-mingw32`
+
    2. For NI Linux Real-Time ARM targets:
 
    .. code:: cmake
@@ -415,7 +421,10 @@ used.
 
 5. The compiler flags, include directories, and sysroot should all be
    defined in the script as well. Note that these are the NI recommended
-   compiler flags.
+   compiler flags. Note that the include directories will vary based on
+   the version of the compiler toolchain and the gcc version included.
+   For example, below is with the 18.0 toolchain which uses 6.3.0, but
+   the 2023Q1 toolchain uses 10.3.0.
 
    1. For NI Linux Real-Time x64 targets:
 

--- a/docs/source/cross_compile/hello_world.rst
+++ b/docs/source/cross_compile/hello_world.rst
@@ -305,9 +305,9 @@ debugging <https://code.visualstudio.com/docs/cpp/launch-json-reference>`__.
    information such as the **miDebuggerPath** completed already as part
    of the template project creation.
 2. | Complete *launch.json* for the “Hello, World!” application as shown
-     below. Specifically, the **program** and **miDebuggerServerAddress**
-     fields using the IP address of the remote NI Linux Real-Time device
-     and the local binary build.
+     in the example for 18.0 below. Specifically, the **program** and
+     **miDebuggerServerAddress** fields using the IP address of the remote
+     NI Linux Real-Time device and the local binary build.
 
    .. code:: json
 


### PR DESCRIPTION
While running through the steps for the 23.0 toolchain release (aka 2023Q1), it was found that a few paths have changed in the toolchain export. Comments have been added to indicate the new paths for 23.0 where appropriate.

[AB#2304836](https://dev.azure.com/ni/94b22d7b-ad7b-4f5e-88f0-867910f91c94/_workitems/edit/2304836)

Signed-off-by: Charlie Johnston <charlie.johnston@ni.com>
