### PR TITLE
call_shared_library: Add required call to ldconfig to tutorial

### DIFF
--- a/docs/source/cross_compile/call_shared_library.rst
+++ b/docs/source/cross_compile/call_shared_library.rst
@@ -350,11 +350,15 @@ permissions can be used.
 
     .. image:: media/call_so/image25.png
 
-14. | Change directories to the location of the deployed binary.
+14. | Run the ``ldconfig`` command. This command will refresh the links
+      and cache used by the system when searching for libraries. The
+      configuration for this utility can be found at ``/etc/ld.so.conf``.
+
+15. | Change directories to the location of the deployed binary.
 
     .. image:: media/call_so/image26.png
 
-15. | Run the executable and confirm that it works properly. Make sure
+16. | Run the executable and confirm that it works properly. Make sure
       to enter input when prompted by the application.
 
     .. image:: media/call_so/image27.png


### PR DESCRIPTION
The tutorial on calling a shared library was missing the call to ldconfig to reload the links and caches for the compiler. Added a step to run the command to refresh things after a user copies the library to /usr/local/lib.

[AB#2377637](https://dev.azure.com/ni/94b22d7b-ad7b-4f5e-88f0-867910f91c94/_workitems/edit/2377637)

![image](https://user-images.githubusercontent.com/5367780/234980615-55e2e6bf-3a52-4420-881e-f9cffca1a45e.png)
