### PR TITLE
config_dev_system: Add 7-Zip admin permission requirement.

### DIFF
--- a/docs/source/cross_compile/config_dev_system.rst
+++ b/docs/source/cross_compile/config_dev_system.rst
@@ -133,6 +133,13 @@ the right location.
    supports. For example, the 2018-2019 toolchain is typically referred
    to as the 18.0 version.
 2. Use 7-Zip to extract the contents of the toolchain.
+
+.. note::
+   Extracting the toolchain requires the ability to create
+   symbolic links or the toolchain will not work properly. On Windows,
+   this requires that the current user have permissions to create
+   symbolic links or that 7-Zip be run as an administrator.
+
 3. | If using an ARMv7 target, extract and copy the contents of the
      toolchain to *C:\\build\\<toolchain version>\\arm\\*. The resulting file
      structure should look as follows:


### PR DESCRIPTION
The toolchain includes symbolic links. On Windows, this requires either a user with permission added or the ability to run programs as an administrator. Otherwise, the symbolic links are not created and the toolchain cannot find some utilities required for compilation.

[AB#2377643](https://dev.azure.com/ni/94b22d7b-ad7b-4f5e-88f0-867910f91c94/_workitems/edit/2377643)

![image](https://user-images.githubusercontent.com/5367780/234993701-340cbac9-89eb-4d6a-a532-702912684293.png)
