### PR TITLE
nilrt-docs: Use note block for notes.

### DIFF
--- a/docs/source/cross_compile/build_shared_library.rst
+++ b/docs/source/cross_compile/build_shared_library.rst
@@ -24,9 +24,10 @@ This tutorial requires the following software and hardware:
 -  A project template as described in Configuring Visual Studio Code for
    Building NI Linux Real-Time C/C++ Code
 
-**Note:** NI recommends completing “Hello, World!” with Visual Studio
-Code and NI Linux Real-Time before attempting this tutorial to ensure
-the template projects are correctly configured.
+.. note::
+   NI recommends completing “Hello, World!” with Visual Studio
+   Code and NI Linux Real-Time before attempting this tutorial to ensure
+   the template projects are correctly configured.
 
 Creating a Project
 ------------------
@@ -130,12 +131,13 @@ documentation <https://cmake.org/cmake/help/latest/>`__.
 
 3. Save *CMakeLists.txt.*
 
-**Note:** If desired, the built binary and other files can be installed
-to a directory on the local system using the `CMake install
-command <https://cmake.org/cmake/help/latest/command/install.html>`__.
-This can automate the process of copying shared libraries and their
-headers to directories on the development host system for future
-development use.
+.. note::
+   If desired, the built binary and other files can be installed
+   to a directory on the local system using the `CMake install
+   command <https://cmake.org/cmake/help/latest/command/install.html>`__.
+   This can automate the process of copying shared libraries and their
+   headers to directories on the development host system for future
+   development use.
 
 Building
 ~~~~~~~~

--- a/docs/source/cross_compile/call_shared_library.rst
+++ b/docs/source/cross_compile/call_shared_library.rst
@@ -102,9 +102,11 @@ time as the built executable.
      *<toolchain root path>/sysroots/
      cortexa9-vfpv3-nilrt-linux-gnueabi/usr/local/include* directory
      depending on the toolchain used.
-   | **Note:** The /usr/local/include directory may not exist in the
-     sysroot by default. If it is not present, simply create the
-     directory.
+
+   .. note::
+      The /usr/local/include directory may not exist in the
+      sysroot by default. If it is not present, simply create the
+      directory.
 
    .. image:: media/call_so/image4.png
 
@@ -498,8 +500,9 @@ as breakpoints are available.
     .. image:: media/call_so/image39.png
     .. image:: media/call_so/image39.png
 
-**Note:** While debugging, not all symbols or source files for the Linux
-Kernel are available. If an attempt to step into that code is made,
-Visual Studio Code may be unable to open or find that certain source
-files. If this occurs, finish debugging with either **Continue** or
-**Stop.**
+.. note::
+   While debugging, not all symbols or source files for the Linux
+   Kernel are available. If an attempt to step into that code is made,
+   Visual Studio Code may be unable to open or find that certain source
+   files. If this occurs, finish debugging with either **Continue** or
+   **Stop.**

--- a/docs/source/cross_compile/config_dev_system.rst
+++ b/docs/source/cross_compile/config_dev_system.rst
@@ -71,10 +71,11 @@ open-source build tools and compilers while providing many features
 users expect from modern code editors such as IntelliSense and
 debugging.
 
-**Note:** Visual Studio Code frequently receives updates and
-improvements to appearance, usability, and functionality. This tutorial
-was created with version 1.38.1 of the environment. Other versions may
-differ in appearance.
+.. note::
+   Visual Studio Code frequently receives updates and
+   improvements to appearance, usability, and functionality. This tutorial
+   was created with version 1.38.1 of the environment. Other versions may
+   differ in appearance.
 
 Installing the IDE
 ~~~~~~~~~~~~~~~~~~
@@ -128,10 +129,13 @@ the right location.
    necessary for a given device, refer to `Real-Time Controllers and
    Real-Time Operating System
    Compatibility. <https://www.ni.com/en-us/support/documentation/compatibility/17/real-time-controllers-and-real-time-operating-system-compatibili.html>`__
-   **Note:** the steps below refer to the *toolchain version*.
+
+.. note:: 
+   The steps below refer to the *toolchain version*.
    Typically, this corresponds to the first version that the toolchain
    supports. For example, the 2018-2019 toolchain is typically referred
-   to as the 18.0 version.
+   to as the 18.0 version.`
+
 2. Use 7-Zip to extract the contents of the toolchain.
 
 .. note::
@@ -152,10 +156,11 @@ the right location.
 
    .. image:: media/config_pc/image5.png
 
-**Note:** Extracting the files may require extracting twice – once to
-unzip, and once to unpack the tar file. During these extractions there
-may be dialogs prompting the replacement of files or warnings. The
-warnings can be safely ignored.
+.. note::
+   Extracting the files may require extracting twice – once to
+   unzip, and once to unpack the tar file. During these extractions there
+   may be dialogs prompting the replacement of files or warnings. The
+   warnings can be safely ignored.
 
 Other Tools
 -----------
@@ -183,11 +188,12 @@ deployment.
 
    .. image:: media/config_pc/image6.png
 
-**Note:** As an alternative to FileZilla, NI recommends the OpenSSH
-command line utilities included with Windows 10 as of the Autumn 2018
-release of that Operating System. Refer to the `official OpenSSH
-documentation <https://www.openssh.com/manual.html>`__ for information
-on its use.
+.. note::
+   As an alternative to FileZilla, NI recommends the OpenSSH
+   command line utilities included with Windows 10 as of the Autumn 2018
+   release of that Operating System. Refer to the `official OpenSSH
+   documentation <https://www.openssh.com/manual.html>`__ for information
+   on its use.
 
 Putty
 ~~~~~

--- a/docs/source/cross_compile/config_vs_code.rst
+++ b/docs/source/cross_compile/config_vs_code.rst
@@ -151,10 +151,11 @@ these steps:
         ]
       }
 
-   **Note:** The “$gcc” problemMatcher value requires the C/C++
-   Extension and allows Visual Studio Code to report compilation errors
-   in the **Problems** view. A problemMatcher of [] means that the
-   output is notscanned for errors and terminal output needs reviewed.
+   .. note::
+      The “$gcc” problemMatcher value requires the C/C++
+      Extension and allows Visual Studio Code to report compilation errors
+      in the **Problems** view. A problemMatcher of [] means that the
+      output is notscanned for errors and terminal output needs reviewed.
 
 6. Save *tasks.json* and then close the file in the editor.
 
@@ -209,7 +210,7 @@ includes and other necessary resources.
            "version": 4
          }
 
-      | **Note:** For toolchain versions 2023Q1 and later, the `compilerPath` is instead `${compilerSysroots}/x86_64-w64-mingw32/usr/bin/x86_64-nilrt-linux/x86_64-nilrt-linux-gcc.exe`.
+      .. note:: For toolchain versions 2023Q1 and later, the `compilerPath` is instead `${compilerSysroots}/x86_64-w64-mingw32/usr/bin/x86_64-nilrt-linux/x86_64-nilrt-linux-gcc.exe`.
 
    2. | For NI Linux Real-Time ARM devices, complete the file as follows:
 
@@ -301,7 +302,7 @@ debugging <https://code.visualstudio.com/docs/cpp/launch-json-reference>`__.
            ]
          }
 
-      | **Note:** For toolchain versions 2023Q1 and later, the `miDebuggerPath` is `C:/build/<toolchain version>/x64/sysroots/x86_64-w64-mingw32/usr/bin/x86_64-nilrt-linux/x86_64-nilrt-linux-gdb.exe`.
+      .. note:: For toolchain versions 2023Q1 and later, the `miDebuggerPath` is `C:/build/<toolchain version>/x64/sysroots/x86_64-w64-mingw32/usr/bin/x86_64-nilrt-linux/x86_64-nilrt-linux-gdb.exe`.
 
    2. | For NI Linux Real-Time ARM devices, complete the file as follows:
 
@@ -352,9 +353,10 @@ required for cross compiling as documented in the CMake Wiki
 `CrossCompiling <https://gitlab.kitware.com/cmake/community/wikis/doc/cmake/CrossCompiling>`__
 document.
 
-**Note:** The below steps assume the 18.0 compiler toolchains and Linux
-Real-Time images. Paths may differ based on the toolchain and versions
-used.
+.. note::
+   The below steps assume the 18.0 compiler toolchains and Linux
+   Real-Time images. Paths may differ based on the toolchain and versions
+   used.
 
 1. In the *build* directory of the project, create a new file using the
    **New File** button. Name the file *CMakeLists.txt*.
@@ -411,7 +413,7 @@ used.
       set(CMAKE_C_COMPILER ${toolchainpath}/i686-nilrtsdk-mingw32/usr/bin/x86_64-nilrt-linux/x86_64-nilrt-linux-gcc.exe)
       set(CMAKE_CXX_COMPILER ${toolchainpath}/i686-nilrtsdk-mingw32/usr/bin/x86_64-nilrt-linux/x86_64-nilrt-linux-g++.exe)
 
-   **Note:** For toolchain versions 2023Q1 and later, replace `i686-nilrtsdk-mingw32` with `x86_64-w64-mingw32`
+   .. note:: For toolchain versions 2023Q1 and later, replace `i686-nilrtsdk-mingw32` with `x86_64-w64-mingw32`
 
    2. For NI Linux Real-Time ARM targets:
 
@@ -448,9 +450,10 @@ used.
       set(CMAKE_<LANG>_FLAGS_RELEASE "-O3")
 
 
-   **Note:** NI recommends using the **-mfpu=vfpv3
-   -mfloat-abi=softfp** flags for ARM targets to improve
-   floating-point operation performance.
+   .. note::
+      NI recommends using the **-mfpu=vfpv3
+      -mfloat-abi=softfp** flags for ARM targets to improve
+      floating-point operation performance.
 
 6. Search behavior must be specified to ensure that the compiler doesn’t
    unnecessarily pull in includes from the host system’s paths. This

--- a/docs/source/cross_compile/hello_world.rst
+++ b/docs/source/cross_compile/hello_world.rst
@@ -29,9 +29,10 @@ This tutorial requires the following software and hardware:
    software installed on this device should match the toolchain version
    used.
 
-**Note:** This tutorial uses a C source file, but the same steps and
-configurations apply to C++ code. CMake can differentiate between C and
-C++ files to ensure the proper compile commands are used.
+.. note::
+  This tutorial uses a C source file, but the same steps and
+  configurations apply to C++ code. CMake can differentiate between C and
+  C++ files to ensure the proper compile commands are used.
 
 Creating a Project
 ------------------
@@ -399,8 +400,9 @@ as breakpoints are available.
     
     .. image:: media/hello_world/image34.png
 
-**Note:** While debugging, not all symbols or source files for the Linux
-Kernel are available. If an attempt to step into that code is made,
-Visual Studio Code may be unable to open or find that certain source
-files. If this occurs, finish debugging with either **Continue** or
-**Stop.**
+.. note::
+  While debugging, not all symbols or source files for the Linux
+  Kernel are available. If an attempt to step into that code is made,
+  Visual Studio Code may be unable to open or find that certain source
+  files. If this occurs, finish debugging with either **Continue** or
+  **Stop.**

--- a/docs/source/cross_compile/introduction.rst
+++ b/docs/source/cross_compile/introduction.rst
@@ -103,9 +103,10 @@ This debugger connects to the remotely running GNU Debugger Server
 (gdbserver) which is included by default on every NI Linux Real-Time
 distribution.
 
-**Note:** Even with the cross compile tools, debugging requires a system
-which can actually run the compiled code. That is, a system running NI
-Linux Real-Time is still necessary for debugging.
+.. note::
+   Even with the cross compile tools, debugging requires a system
+   which can actually run the compiled code. That is, a system running NI
+   Linux Real-Time is still necessary for debugging.
 
 Getting Started
 ---------------

--- a/docs/source/opkg/dkms_opkg.rst
+++ b/docs/source/opkg/dkms_opkg.rst
@@ -125,11 +125,12 @@ official documentation.
 Configuring the System
 ======================
 
-**Note:** DKMS will already be installed when using NI Linux Real-Time
-Operating System versions 8.0.0 and later or when using a PXI Linux
-Real-Time controller. When using older systems, running the
-**updateNIDriver** commands on non-\*.ipk systems can cause problems with
-DKMS.
+.. note::
+   DKMS will already be installed when using NI Linux Real-Time
+   Operating System versions 8.0.0 and later or when using a PXI Linux
+   Real-Time controller. When using older systems, running the
+   **updateNIDriver** commands on non-\*.ipk systems can cause problems with
+   DKMS.
 
 Before starting, the required software and toolchains must be installed
 to the NI Linux Real-Time system used. This can be accomplished through
@@ -327,7 +328,7 @@ covered in the official opkg documentation, an \*.ipk requires three
 things with the other items being optional:
 
 1. A *CONTROL* directory with a *control* file.
-   **Note:** Keep in mind that Linux is case sensitive.
+   .. note:: Keep in mind that Linux is case sensitive.
 2. The data files to be installed in their proper directory structure.
    In this tutorial, these files are the same as used when testing the
    DKMS module previously.
@@ -387,9 +388,10 @@ As mentioned previously, there are two scripts required when creating
 handle the registration, installation, and removal of modules from DKMS
 during installation and removal of the package.
 
-**Note:** In order to build a package, all scripts must have executable
-privileges. To ensure that this is the case, run **chmod a+x <script>**
-before attempting to build a package.
+.. note::
+   In order to build a package, all scripts must have executable
+   privileges. To ensure that this is the case, run **chmod a+x <script>**
+   before attempting to build a package.
 
 postinst
 ~~~~~~~~

--- a/docs/source/opkg/opkg_intro.rst
+++ b/docs/source/opkg/opkg_intro.rst
@@ -167,7 +167,7 @@ covered in the official opkg documentation, an \*.ipk requires a few
 things with the other items being optional:
 
 1. A *CONTROL* directory with a *control* file.
-   **Note:** Keep in mind that Linux is case sensitive.
+   .. note:: Keep in mind that Linux is case sensitive.
 2. The data files to be installed in their proper directory structure.
 
 The optional components required for a package are:
@@ -219,9 +219,10 @@ As mentioned previously, there are two optional scripts when creating
 registration, installation, and removal of files during installation and
 removal of the package.
 
-**Note:** In order to build a package, all scripts must have executable
-privileges. To ensure that this is the case, run **chmod a+x <script>**
-before attempting to build a package.
+.. note::
+   In order to build a package, all scripts must have executable
+   privileges. To ensure that this is the case, run **chmod a+x <script>**
+   before attempting to build a package.
 
 preinst
 ~~~~~~~

--- a/docs/source/remote/vscode_remote.rst
+++ b/docs/source/remote/vscode_remote.rst
@@ -20,9 +20,11 @@ Requirements
 -  Visual Studio Code with the `Remote – SSH
    Extension <https://code.visualstudio.com/docs/remote/ssh>`__
 -  `NI Linux Real-Time x64 System <https://www.ni.com/en-us/support/documentation/compatibility/17/real-time-controllers-and-real-time-operating-system-compatibili.html>`_
-   -  **Note:** The system should not be in safe mode and should have
-   software installed. ARMv7 NI Linux Real-Time devices are not
-   supported.
+
+   .. note::
+      The system should not be in safe mode and should have
+      software installed. ARMv7 NI Linux Real-Time devices are not
+      supported.
 
 A Note on Support
 -----------------
@@ -58,7 +60,7 @@ Real-Time. No cross compiling is necessary, and dependencies can be
 installed directly to the remote system without concern of linker errors
 when deploying.
 
-**Note:** For more information on cross compiling, refer to NI Linux
+For more information on cross compiling, refer to NI Linux
 Real-Time Cross Compiling: Using the NI Linux Real-Time Cross Compile
 Toolchain with Visual Studio Code.
 
@@ -172,14 +174,16 @@ Visual Studio Code.
    .. image:: media/image8.png
 
 #. | Visual Studio Code will install the required remote components.
-   | **Note:** You may receive the following warning message:
 
-   .. image:: media/image9.png
+   .. note::
+      You may receive the following warning message:
 
-   This message can be safely ignored after confirming the proper
-   versions. Refer to `Remote host / container / WSL Linux
-   prerequisites <https://code.visualstudio.com/docs/remote/linux#_remote-host-container-wsl-linux-prerequisites>`__
-   for more information.
+      .. image:: media/image9.png
+
+      This message can be safely ignored after confirming the proper
+      versions. Refer to `Remote host / container / WSL Linux
+      prerequisites <https://code.visualstudio.com/docs/remote/linux#_remote-host-container-wsl-linux-prerequisites>`__
+      for more information.
 
 Adding Remote Visual Studio Code Extensions
 -------------------------------------------
@@ -211,11 +215,12 @@ Studio Code environment for remote development. To add this extension:
 
    .. image:: media/image12.png
 
-**Note:** Using the C/C++ extension will keep an IntelliSense cache on
-the remote target. This has the potential to get very large with larger
-projects. The
-`C_Cpp.intelliSenseCacheSize <https://code.visualstudio.com/docs/cpp/faq-cpp#_what-is-the-ipch-folder>`__
-property can be used to mitigate this.
+.. note::
+   Using the C/C++ extension will keep an IntelliSense cache on
+   the remote target. This has the potential to get very large with larger
+   projects. The
+   `C_Cpp.intelliSenseCacheSize <https://code.visualstudio.com/docs/cpp/faq-cpp#_what-is-the-ipch-folder>`__
+   property can be used to mitigate this.
 
 Building, Running, and Debugging a C/C++ “Hello, World!” Program
 ================================================================
@@ -239,9 +244,10 @@ C/C++ extension.
    .. image:: media/image13.png
 
 #. | In Visual Studio Code, open the folder by navigating to **File >>
-     Open Folder**, then entering the file path desired. **Note:** You
-     can also open local folders but doing so will close the SSH
-     Connection and revert VS Code to a local environment.
+     Open Folder**, then entering the file path desired.
+     .. note::
+        You can also open local folders but doing so will close the SSH
+        Connection and revert VS Code to a local environment.
    
    .. image:: media/image14.png
 

--- a/docs/source/troubleshooting/logs.rst
+++ b/docs/source/troubleshooting/logs.rst
@@ -22,7 +22,7 @@ The ``/var/volatile/log/`` directory is mapped to RAM instead of the persistent 
 This prevents the system’s device storage from filling with logs and causing other issues on devices with extremely limited storage but results in the logs not persisting through a reboot.
 To make these logs persist through a reboot, see the Enabling Persistent Logs section of this document.
 
-**Note:** The ``kern.log`` file is traditionally stored here, but on NI Linux Real-Time systems is instead located at ``/var/local/natinst/log/`` to ensure it persists between reboots.
+.. note:: The ``kern.log`` file is traditionally stored here, but on NI Linux Real-Time systems is instead located at ``/var/local/natinst/log/`` to ensure it persists between reboots.
 
 .. csv-table:: NI Linux RT Logs
    :file: resources/nilrt-logs.csv
@@ -109,8 +109,9 @@ Additionally, the frequent logging to disk may impact the disk's lifetime.
 Configuring the system such that the logs persist after a reboot requires modifying the behavior used to populate system volatiles for the ``/var/log`` location.
 Note that the default behavior is inherited from the upstream OpenEmbedded/Yocto distributions that NI Linux Real-Time is based on.
 
-**Note:** These settings will only persist until a format or software upgrade is made.
-Once that happens, the Linux Real-Time settings may revert to their defaults for that version.
+.. note::
+   These settings will only persist until a format or software upgrade is made.
+   Once that happens, the Linux Real-Time settings may revert to their defaults for that version.
 
 To modify these settings for the ``/var/log`` location:
 
@@ -151,8 +152,9 @@ NILRT < 9.1
 
    ``rm /var/log``
 
-   **Note:** Do not add a trailing slash when removing the symlink.
-   Doing so will not behave as intended.
+   .. note::
+     Do not add a trailing slash when removing the symlink.
+     Doing so will not behave as intended.
 
 4. Create a new ``/var/log`` directory so that the location is present upon reboot.
 


### PR DESCRIPTION
Sphinx allows for using a note block to format notes in documents. This change updates all previous notes to use that format as it's more noticeable and consistent with other Sphinx documents.

## Testing:
Built locally and confirmed proper formatting of all the notes.