### PR TITLE
CODEOWNERS: Make Mike the new owner.

### DIFF
--- a/.github/workflows/publish-page.yml
+++ b/.github/workflows/publish-page.yml
@@ -19,7 +19,7 @@ jobs:
         documentation_path: './docs/source'
     - name: Preserve Configuration Files
       run: |
-        git checkout main -- CODEOWNERS
+        echo "* @mike-petersen-ni" > CODEOWNERS
         git checkout gh-pages^ -- CNAME
     - name: Create Pull Request
       uses: peter-evans/create-pull-request@v4

--- a/CODEOWNERS
+++ b/CODEOWNERS
@@ -1,2 +1,2 @@
 # Default code owner for the repository
-* @SparkingSpork
+* @mike-petersen-ni


### PR DESCRIPTION
Added Mike as the new codeowner.

To preserve the code owner for the publishing PRs as just Mike, the workflow was also updated to explicitly push him only as the code owner. Otherwise, all code owners would be added to the publishing PRs.

## Note:
We will eventually want Kayla as a reviewer for the non-publishing PRs, but adding Mike in the meantime.

## Testing:
N/A