### PR TITLE
drivers/nirtfeatures: document poweron reset_source string

### DIFF
--- a/docs/source/drivers/nirtfeatures.rst
+++ b/docs/source/drivers/nirtfeatures.rst
@@ -15,11 +15,12 @@ SysFS
 reset_source
 ------------
 
-The `reset_source` sysfs entry is read-only, and exposes a single word which describes the state of the CPLD's `ProcResetSourceReg` register. Possible values are defined by the `nirtfeatures.c:nirtfeatures_reset_source_string <https://github.com/ni/linux/blob/81fc9e513b095c0008520d7a55dabc3ef3531539/drivers/misc/nirtfeatures.c#L230>`_ constant.
+The `reset_source` sysfs entry is read-only, and exposes a single word which describes the state of the CPLD's `ProcResetSourceReg` register. Possible values are defined by the possible return values of the `nirtfeatures.c:nirtfeatures_reset_source_get() <https://github.com/ni/linux/blob/b162dea3fba40d50016831993491ad814c3d5742/drivers/misc/nirtfeatures.c#L234>`_ function.
 
 :button: The CPLD came out of reset due to someone toggling the front-panel reset button.
 :fpga: The CPLD came out of reset because the onboard FPGA received a reset signal.
 :ironclad: The CPLD came out of reset because the *Ironclad* watchdog timer expired.
+:poweron: The system was not reset using the CPLD.
 :processor: The CPLD came out of reset due to a reset occuring internal to the processor. Most often, this is due to a user-space process rebooting or shutting down the system from software.
 :software: The CPLD came out of reset because the processor wrote a `1` to the `ResetProcessor` bit of the `ProcessorModeReg` CPLD register.
 :watchdog: The CPLD came out of reset because the niwatchdog timer expired.


### PR DESCRIPTION
The nirtfeatures driver will write the string "poweron" into the reset_source sysfs entry when the CPLD was not *reset* (ie. the register is 0x00).

Document this state.

[AB#2582066](https://dev.azure.com/ni/94b22d7b-ad7b-4f5e-88f0-867910f91c94/_workitems/edit/2582066)

# Testing
* [x] Sphinx builds without errors or warnings.
![image](https://github.com/ni/nilrt-docs/assets/10503146/82fb509e-3e8f-4c48-b91b-05783e23f812)