### PR TITLE
docs: link to the official putty.software site.

### DIFF
--- a/docs/source/cross_compile/config_dev_system.rst
+++ b/docs/source/cross_compile/config_dev_system.rst
@@ -41,7 +41,7 @@ briefly covers each tool and how to set it up.
 
 -  FileZilla
 
--  PuTTY
+-  `PuTTY`_
 
 -  CMake
 
@@ -304,7 +304,7 @@ Putty
 .. note::
    Windows only application
 
-`PuTTY <https://putty.org/>`__ is a free and open-source terminal
+`PuTTY`_ is a free and open-source terminal
 emulator, serial console and network file transfer application. In this
 use case, we’ll be using it as an SSH Client to interact with the remote
 system.
@@ -430,3 +430,6 @@ Next Steps
 
 With the software installed, it’s time to configure Visual Studio Code
 for a project using the NI Linux Real-Time compilers.
+
+
+.. _PuTTY: https://putty.software/

--- a/docs/source/opkg/dkms_opkg.rst
+++ b/docs/source/opkg/dkms_opkg.rst
@@ -136,7 +136,7 @@ Before starting, the required software and toolchains must be installed
 to the NI Linux Real-Time system used. This can be accomplished through
 console access to the device via a serial port, SSH, or direct access
 via a keyboard and monitor. For the screenshots in this tutorial, SSH is
-used via `PuTTY <https://www.putty.org/>`__.
+used via `PuTTY`_.
 
 1. Open a console to the NI Linux Real-Time system and log in as or
    switch to the **admin** user.
@@ -524,7 +524,11 @@ Resources
    Guide <https://www.tldp.org/LDP/lkmpg/2.6/html/>`__
 -  `Dynamic Kernel Module Support
    source <https://github.com/dell/dkms>`__
--  `Putty <https://www.putty.org/>`__
+-  `PuTTY`_
 -  `dkms(8) - Linux man page <https://linux.die.net/man/8/dkms>`__
 -  `Getting Started with C/C++ Development Tools for NI Linux Real-Time,
    Eclipse Edition <http://www.ni.com/tutorial/14625/en/>`__
+
+
+
+.. _PuTTY: https://putty.software/

--- a/docs/source/opkg/opkg_intro.rst
+++ b/docs/source/opkg/opkg_intro.rst
@@ -68,7 +68,7 @@ Before starting, the required software and toolchains must be installed
 to the NI Linux Real-Time system used. This can be accomplished through
 console access to the device via a serial port, SSH, or direct access
 via a keyboard and monitor. For the screenshots in this tutorial, SSH is
-used via \ `PuTTY <https://www.putty.org/>`__.
+used via `PuTTY`_.
 
 1. Open a console to the NI Linux Real-Time system and log in as or
    switch to the **admin** user.
@@ -310,6 +310,9 @@ Resources
    Guide <https://www.tldp.org/LDP/lkmpg/2.6/html/>`__
 -  `Dynamic Kernel Module Support
    source <https://github.com/dell/dkms>`__
--  `Putty <https://www.putty.org/>`__
+-  `PuTTY`_
 -  `Getting Started with C/C++ Development Tools for NI Linux Real-Time,
    Eclipse Edition <http://www.ni.com/tutorial/14625/en/>`__
+
+
+.. _PuTTY: https://putty.software/


### PR DESCRIPTION
# Summary

putty.org is not the official software site of the PuTTY project and, as of late July 2025, has little to do with the real software. Change PuTTY links throughout the docs to reference `putty.software`, the new official site.

# Testing

Hand-tested all the links and confirmed that they now link to https://putty.software.