### PR TITLE
workflows: insert CNAME designation when publishing

### DIFF
--- a/.github/workflows/publish-page.yml
+++ b/.github/workflows/publish-page.yml
@@ -18,6 +18,9 @@ jobs:
       - name: Build project
         uses: ./.github/actions/build
 
+      - name: Set up CNAME for GitHub Pages
+        run: echo "nilrt-docs.ni.com" >docs/build/html/CNAME
+
       - name: Deploy to GitHub Pages
         uses: peaceiris/actions-gh-pages@v4
         with:


### PR DESCRIPTION
The canonical nilrt-docs.ni.com subdomain tries to redirect to GH pages. And it requires the Github custom domain configuration subsystem to work, which means that the gh-pages ref must have a CNAME file with the correct CNAME in it. But since that branch contents is entirely composed of the built html files, we must insert the CNAME file in the workflow.

Abbreviated PR. Hotfix for main.