### PR TITLE
Update docker documentation

### DIFF
--- a/docs/source/docker/docker.rst
+++ b/docs/source/docker/docker.rst
@@ -29,7 +29,7 @@ from your target:
 
 .. note::
 
-    Currently Docker will not function correctly if you have LabVIEW RT installed.
+    Docker cannot be used in combination with LabVIEW RT versions older than 26.0 due to cgroups v1 resource utilization conflicts present in those prior versions.
 
 Once installed, you can verify it was set up correctly by running:
 

--- a/docs/source/docker/docker.rst
+++ b/docs/source/docker/docker.rst
@@ -25,7 +25,7 @@ from your target:
 
 .. code:: bash
     
-    opkg install docker-ce
+    opkg install docker
 
 .. note::
 

--- a/docs/source/docker/docker.rst
+++ b/docs/source/docker/docker.rst
@@ -31,6 +31,9 @@ from your target:
 
     Docker cannot be used in combination with LabVIEW RT versions older than 26.0 due to cgroups v1 resource utilization conflicts present in those prior versions.
 
+.. note::
+    At this time, Docker is not compatible with 32-bit ARM (armv7l) NI Linux RT targets. You can check the target CPU architecture using the ``uname -m`` command.
+
 Once installed, you can verify it was set up correctly by running:
 
 .. code:: bash


### PR DESCRIPTION
Update docker documentation to:

- Fix the package name used for installs i.e. use the meta package name 'docker'
- Indicate that the incompatibility with LabVIEW RT only applies to versions older than 26.0
- Add note about Docker currently being incompatible with ARM32 based targets