### PR TITLE
gcc_version: Update table for 2026 Q3

### DIFF
--- a/docs/source/cross_compile/media/toolchain/gcc_versions.csv
+++ b/docs/source/cross_compile/media/toolchain/gcc_versions.csv
@@ -9,3 +9,4 @@ Toolchain Version,GCC Version
 2025 Q2,13.3.0
 2025 Q3,13.3.0
 2025 Q4,13.4.0
+2026 Q3,13.4.0


### PR DESCRIPTION
Updated the x64 GCC version for 2026 Q3.
WI: [AB#3738552](https://dev.azure.com/ni/94b22d7b-ad7b-4f5e-88f0-867910f91c94/_workitems/edit/3738552)